### PR TITLE
Fix chat padding when the right column is visible

### DIFF
--- a/src/scss/partials/_chat.scss
+++ b/src/scss/partials/_chat.scss
@@ -1796,7 +1796,17 @@ $time-margin-left: math.div($message-padding-horizontal, -2) + 1px;
 
 	@include respond-to(medium-screens) {
 		width: calc(100% - var(--right-column-width));
+    transition: width var(--transition-standard-in);
 	}
+
+  // fix padding when the right column is visible
+  body.is-right-column-shown & {
+    width: calc(100% - var(--right-column-width) - (var(--chat-input-padding)*2) - 11px); // 11px is tail width
+    // don't count tail width in groups
+    &.is-chat {
+      width: calc(100% - var(--right-column-width) - (var(--chat-input-padding)*2));
+    }
+  }
 
 	// @include respond-to(handhelds) {
   //   padding: 0 $chat-padding-handhelds;


### PR DESCRIPTION
This pull request fixes a small visual issue in chats.

When the right column (chat info) is visible, messages lose their padding.

<img width="250" alt="Cropped screenshot of a chat, showing that messages have no padding" src="https://github.com/morethanwords/tweb/assets/17374742/3c7c9ba7-f50f-4a83-8228-89c731a0330c">

After the changes in this pull request, messages have a bit of padding, equal to that of the new message field.

<img width="250" alt="Cropped screenshot of the same chat, showing that messages have a bit of padding" src="https://github.com/morethanwords/tweb/assets/17374742/997bfd86-ba73-4588-8ea2-c8fe6def0e09">
