### PR TITLE
Prevent duplicate 'when?' elements in user status

### DIFF
--- a/src/components/peerProfile.ts
+++ b/src/components/peerProfile.ts
@@ -358,6 +358,11 @@ export default class PeerProfile {
       if(peerId.isUser()) {
         const user = apiManagerProxy.getUser(peerId.toUserId());
         if((user.status as UserStatus.userStatusRecently)?.pFlags?.by_me) {
+          // Don't append the when element if it's already been added
+          if(this.subtitle.querySelector('.show-when')) {
+            return;
+          }
+
           const when = i18n('StatusHiddenShow');
           when.classList.add('show-when');
           attachClickEvent(when, (e) => {


### PR DESCRIPTION
This pull request adds a check to prevent duplicate 'when' elements from being added to the user status while the user is typing. (#311)