### PR TITLE
The language subtitle was aligned to the left edge, to correct this:

### DIFF
--- a/src/scss/partials/_row.scss
+++ b/src/scss/partials/_row.scss
@@ -122,6 +122,7 @@ $row-border-radius: $border-radius-medium;
   &-subtitle-row,
   & > &-subtitle {
     order: 1;
+    text-align: left;
   }
 
   // &-title,


### PR DESCRIPTION
![image](https://github.com/morethanwords/tweb/assets/65463560/051b2d4e-91cc-4eec-9bcc-7d2a9b4fd291)
![image](https://github.com/morethanwords/tweb/assets/65463560/770bdded-9f8a-47c0-8157-e8f5a24d313e)