### PR TITLE
Fix sending HTML with comment

### DIFF
--- a/src/components/inputField.ts
+++ b/src/components/inputField.ts
@@ -184,7 +184,7 @@ let init = () => {
       // console.log(html.replace(/ (style|class|id)=".+?"/g, ''));
 
       html = html.replace(/<style([\s\S]*)<\/style>/, '');
-      html = html.replace(/<!--([\s\S]*)-->/, '');
+      html = html.replace(/<!--([\s\S]*?)-->/, '');
       html = html.replace('<br class="Apple-interchange-newline">', '');
 
       const match = html.match(/<body>([\s\S]*)<\/body>/);


### PR DESCRIPTION
For example:  Copy a link on Windows the HTML in clipboard will be:

```html
<html> 
<body> 
<!--StartFragment--><a href="https://web.telegram.org/k/">Telegram Web</a><!--EndFragment--> 
</body> 
</html>
```

The `*` in regex is greedy, it will match to last comment ending, out put became this: 

```html
<html> 
<body> 

</body> 
</html>
```


 `*?` is the lazy mode will only match to the first endding, result will like this:

```html
<html> 
<body> 
<a href="https://web.telegram.org/k/">Telegram Web</a>
</body> 
</html>
```
