### PR TITLE
fix deleteMegagroupMessages.tsx,checkbox not processed correctly

### DIFF
--- a/src/components/popups/deleteMegagroupMessages.tsx
+++ b/src/components/popups/deleteMegagroupMessages.tsx
@@ -66,7 +66,7 @@ export default class PopupDeleteMegagroupMessages extends PopupElement {
         acc.set(field.peerId, set = new Set());
       }
 
-      if(field.checked) {
+      if(field.checkboxField.checked) {
         set.add(field.action);
       }
       return acc;


### PR DESCRIPTION
fix deleteMegagroupMessages.tsx,when select report spam,delete all from user,ban user.check box is selected,but not working