### PR TITLE
fix(ts): correct conditional return types

### DIFF
--- a/src/components/peerProfile.ts
+++ b/src/components/peerProfile.ts
@@ -644,7 +644,11 @@ export default class PeerProfile {
 
   private setAvatar<T extends boolean>(manual?: T): T extends true ? Promise<() => void> : Promise<void> {
     const promise = this._setAvatar();
-    return manual ? promise : promise.then((callback) => callback()) as any;
+    if(manual) {
+      return promise as T extends true ? Promise<() => void> : Promise<void>;
+    } else {
+      return promise.then((callback) => callback()) as T extends true ? Promise<() => void> : Promise<void>;
+    }
   }
 
   private getUsernamesAlso(usernames: string[]) {

--- a/src/components/sidebarRight/tabs/sharedMedia.ts
+++ b/src/components/sidebarRight/tabs/sharedMedia.ts
@@ -621,7 +621,12 @@ export default class AppSharedMediaTab extends SliderSuperTab {
       this.editBtn.classList.toggle('hide', !show);
     };
 
-    return manual ? callback : callback() as any;
+    if(manual) {
+      return callback as T extends true ? () => void : void;
+    } else {
+      callback();
+      return undefined as T extends true ? () => void : void;
+    }
   }
 
   public loadSidebarMedia(single: boolean, justLoad?: boolean) {

--- a/src/components/wrappers/getPeerTitle.ts
+++ b/src/components/wrappers/getPeerTitle.ts
@@ -67,5 +67,5 @@ export default async function getPeerTitle<
     title = _limitSymbols(title, limitSymbols, limitSymbols);
   }
 
-  return plainText ? title : wrapEmojiText(title) as any;
+  return plainText ? title as R : wrapEmojiText(title) as any;
 }

--- a/src/components/wrappers/messageActionTextNew.ts
+++ b/src/components/wrappers/messageActionTextNew.ts
@@ -21,6 +21,6 @@ export default async function wrapMessageActionTextNew<T extends WrapMessageActi
     return await wrapMessageActionTextNewUnsafe(options) as any;
   } catch(err) {
     console.error('wrapMessageActionTextNewUnsafe error:', err);
-    return options.plain ? '' : document.createElement('span') as any;
+    return options.plain ? '' as T['plain'] extends true ? string : HTMLElement : document.createElement('span') as any;
   }
 }

--- a/src/components/wrappers/messageActionTextNewUnsafe.ts
+++ b/src/components/wrappers/messageActionTextNewUnsafe.ts
@@ -78,7 +78,8 @@ export async function wrapTopicIcon<T extends WrapTopicIconOptions>(options: T):
   }
 
   return options.plain ?
-    rootScope.managers.appEmojiManager.getCustomEmojiDocument(iconEmojiId).then((doc) => doc.stickerEmojiRaw) :
+    rootScope.managers.appEmojiManager.getCustomEmojiDocument(iconEmojiId)
+    .then((doc) => doc.stickerEmojiRaw as T['plain'] extends true ? string : HTMLElement | DocumentFragment) :
     wrapCustomEmojiAwaited({
       ...options,
       docIds: [iconEmojiId]


### PR DESCRIPTION
Replaced ternary expressions with if/else + type assertions to avoid TS2322 errors when plain mode is enabled.

### 🐞 Problem
Several TypeScript errors occurred when using conditional return types like:

```ts
T['plain'] extends true ? string : HTMLElement | DocumentFragment

TypeScript cannot infer the correct return type at runtime based on options.plain, and throws errors like:

Type 'string' is not assignable to type 'T["plain"] extends true ? string : HTMLElement'.
```
📁 Affected Files
-wrapTopicIcon.ts
-wrapMessageActionTextNew.ts
-getPeerTitle.ts
-toggleEditBtn.ts
-setAvatar.ts

This PR fixes type errors and improves maintainability without altering runtime behavior.
Let me know if you'd prefer this split into smaller PRs by file/function.

Thank you for reviewing!