### PR TITLE
Reconnect the windows in SW on dev

### DIFF
--- a/src/lib/serviceWorker/index.service.ts
+++ b/src/lib/serviceWorker/index.service.ts
@@ -27,6 +27,7 @@ import cryptoMessagePort from '../crypto/cryptoMessagePort';
 import EncryptionKeyStore from '../passcode/keyStore';
 import DeferredIsUsingPasscode from '../passcode/deferredIsUsingPasscode';
 import {onBackgroundsFetch} from './backgrounds';
+import {watchMtprotoOnDev} from './watchMtprotoOnDev';
 
 // #if MTPROTO_SW
 // import '../mtproto/mtproto.worker';
@@ -193,6 +194,8 @@ listenMessagePort(serviceMessagePort, undefined, (source) => {
 // #endif
 
 watchHlsStreamChunksLifetime();
+
+watchMtprotoOnDev({connectedWindows, onWindowConnected});
 
 const onFetch = (event: FetchEvent): void => {
   if(

--- a/src/lib/serviceWorker/watchMtprotoOnDev.ts
+++ b/src/lib/serviceWorker/watchMtprotoOnDev.ts
@@ -1,0 +1,50 @@
+import {getWindowClients} from '../../helpers/context';
+import {IS_BETA} from '../../config/debug';
+
+import {logger, LogTypes} from '../logger';
+
+
+const logMtprotoBug = logger('SW-mtproto-bug', LogTypes.Debug);
+
+type Args = {
+  connectedWindows: Map<string, WindowClient>;
+  onWindowConnected: (source: WindowClient) => void;
+};
+
+export function watchMtprotoOnDev({connectedWindows, onWindowConnected}: Args) {
+  if(IS_BETA) setInterval(() => {
+    logMtprotoBug.debug('checking');
+
+    if(!connectedWindows.size) {
+      getWindowClients().then((windowClients) => {
+        logMtprotoBug.debug(`got ${windowClients.length} windows`);
+
+        windowClients.forEach((windowClient) => {
+          onWindowConnected(windowClient);
+        });
+      });
+    } else {
+      logMtprotoBug.debug('has-windows');
+    }
+
+    // const timeout = self.setTimeout(() => {
+    //   if(!connectedWindows.size) return;
+
+    //   logMtprotoBug.debug('triggered');
+
+    //   if(_mtprotoMessagePort) serviceMessagePort.detachPort(_mtprotoMessagePort);
+    //   else serviceMessagePort.cancelAllTasks();
+    //   logMtprotoBug.debug('cleared port ', _mtprotoMessagePort ? 'attached' : 'all');
+
+    //   const it = connectedWindows.values().next();
+    //   if(!it.done) {
+    //     sendMessagePort(it.value);
+    //     logMtprotoBug.debug('updated port');
+    //   }
+    // }, 0.5e3);
+
+  // serviceMessagePort.invoke('pingMtProtoWorker', undefined).catch(noop).finally(() => {
+  //   self.clearTimeout(timeout);
+  // });
+  }, 2e3);
+}


### PR DESCRIPTION
[DEV] On refresh / hot reload the Service worker loses the connected windows, but doesn't get them back, which makes it lose the connection with the mtproto worker. Somewhy it breaks only the HLS streaming, while simple streaming usually works normally

![image](https://github.com/user-attachments/assets/5b555439-e464-4d76-a338-13a13c18c42d)

![image](https://github.com/user-attachments/assets/38cbbf25-9b8c-4235-a09b-d240d845c32c)
