### PR TITLE
Fix errors for new TS version

### DIFF
--- a/src/components/passcodeLock/passcodeLockScreen.tsx
+++ b/src/components/passcodeLock/passcodeLockScreen.tsx
@@ -6,6 +6,8 @@ import AccountController from '../../lib/accounts/accountController';
 import {MAX_PASSCODE_LENGTH} from '../../lib/passcode/constants';
 import {usePasscodeActions} from '../../lib/passcode/actions';
 import commonStateStorage from '../../lib/commonStateStorage';
+import throttle from '../../helpers/schedulers/throttle';
+import focusInput from '../../helpers/dom/focusInput';
 import pause from '../../helpers/schedulers/pause';
 import {i18n} from '../../lib/langPack';
 
@@ -20,8 +22,6 @@ import SimplePopup from './simplePopup';
 import Background from './background';
 
 import styles from './passcodeLockScreen.module.scss';
-import focusInput from '../../helpers/dom/focusInput';
-import throttle from '../../helpers/schedulers/throttle';
 
 
 type StateStore = {

--- a/src/components/peerProfile.ts
+++ b/src/components/peerProfile.ts
@@ -642,9 +642,12 @@ export default class PeerProfile {
     };
   }
 
-  private setAvatar<T extends boolean>(manual?: T): T extends true ? Promise<() => void> : Promise<void> {
+  private setAvatar(manual: true): Promise<() => void>;
+  private setAvatar(manual?: false): Promise<void>;
+
+  private setAvatar(manual?: boolean): Promise<(() => void) | void> {
     const promise = this._setAvatar();
-    return manual ? promise : promise.then((callback) => callback()) as any;
+    return manual ? promise : promise.then((callback) => callback());
   }
 
   private getUsernamesAlso(usernames: string[]) {

--- a/src/components/sidebarRight/tabs/sharedMedia.ts
+++ b/src/components/sidebarRight/tabs/sharedMedia.ts
@@ -601,7 +601,10 @@ export default class AppSharedMediaTab extends SliderSuperTab {
     };
   }
 
-  private async toggleEditBtn<T extends boolean>(manual?: T): Promise<T extends true ? () => void : void> {
+  private async toggleEditBtn(manual: true): Promise<() => void>;
+  private async toggleEditBtn(manual?: false): Promise<void>;
+
+  private async toggleEditBtn(manual?: boolean): Promise<(() => void) | void> {
     const {peerId} = this;
     let show: boolean;
     if(peerId.isUser()) {
@@ -621,7 +624,7 @@ export default class AppSharedMediaTab extends SliderSuperTab {
       this.editBtn.classList.toggle('hide', !show);
     };
 
-    return manual ? callback : callback() as any;
+    return manual ? callback : callback();
   }
 
   public loadSidebarMedia(single: boolean, justLoad?: boolean) {

--- a/src/components/webApp.ts
+++ b/src/components/webApp.ts
@@ -573,14 +573,17 @@ export default class WebApp {
     }
   }
 
-  public async getTitle<T extends boolean>(plain: T): Promise<T extends true ? string : HTMLElement> {
+  public async getTitle(plain: true): Promise<string>;
+  public async getTitle(plain: false): Promise<HTMLElement | DocumentFragment>;
+
+  public async getTitle(plain: boolean): Promise<string | HTMLElement | DocumentFragment> {
     if(!this.attachMenuBot) {
       const peerId = this.getPeerId();
       if(plain) return getPeerTitle({peerId, plainText: true});
-      else return wrapPeerTitle({peerId}) as any;
+      else return wrapPeerTitle({peerId});
     } else {
-      if(plain) return this.attachMenuBot.short_name as any;
-      else return wrapEmojiText(this.attachMenuBot.short_name) as any;
+      if(plain) return this.attachMenuBot.short_name;
+      else return wrapEmojiText(this.attachMenuBot.short_name);
     }
   }
 

--- a/src/components/wrappers/getPeerTitle.ts
+++ b/src/components/wrappers/getPeerTitle.ts
@@ -21,12 +21,11 @@ type GetPeerTitleOptions = {
   useManagers?: boolean
 } & Pick<WrapSomethingOptions, 'managers'>;
 
-export default async function getPeerTitle<
-  T extends GetPeerTitleOptions,
-  R = T['plainText'] extends true ? string : DocumentFragment
->(
-  options: T
-): Promise<R> {
+export default async function getPeerTitle(options: GetPeerTitleOptions & {plainText: true}): Promise<string>;
+export default async function getPeerTitle(options: GetPeerTitleOptions & {plainText?: false}): Promise<DocumentFragment>;
+export default async function getPeerTitle(options: GetPeerTitleOptions): Promise<string | DocumentFragment>;
+
+export default async function getPeerTitle(options: GetPeerTitleOptions): Promise<string | DocumentFragment> {
   const {
     peerId = rootScope.myId,
     plainText,
@@ -67,5 +66,5 @@ export default async function getPeerTitle<
     title = _limitSymbols(title, limitSymbols, limitSymbols);
   }
 
-  return plainText ? title : wrapEmojiText(title) as any;
+  return plainText ? title : wrapEmojiText(title);
 }

--- a/src/components/wrappers/messageActionTextNew.ts
+++ b/src/components/wrappers/messageActionTextNew.ts
@@ -14,13 +14,15 @@ export type WrapMessageActionTextOptions = {
   noTextFormat?: boolean
 } & WrapSomethingOptions;
 
-export default async function wrapMessageActionTextNew<T extends WrapMessageActionTextOptions>(
-  options: T
-): Promise<T['plain'] extends true ? string : HTMLElement> {
+export default async function wrapMessageActionTextNew(options: WrapMessageActionTextOptions & {plain: true}): Promise<string>;
+export default async function wrapMessageActionTextNew(options: WrapMessageActionTextOptions & {plain?: false}): Promise<HTMLElement>;
+export default async function wrapMessageActionTextNew(options: WrapMessageActionTextOptions): Promise<string | HTMLElement>;
+
+export default async function wrapMessageActionTextNew(options: WrapMessageActionTextOptions): Promise<string | HTMLElement> {
   try {
-    return await wrapMessageActionTextNewUnsafe(options) as any;
+    return await wrapMessageActionTextNewUnsafe(options);
   } catch(err) {
     console.error('wrapMessageActionTextNewUnsafe error:', err);
-    return options.plain ? '' : document.createElement('span') as any;
+    return options.plain ? '' : document.createElement('span');
   }
 }

--- a/src/components/wrappers/messageActionTextNewUnsafe.ts
+++ b/src/components/wrappers/messageActionTextNewUnsafe.ts
@@ -50,7 +50,12 @@ type WrapTopicIconOptions = {
   topic: Pick<ForumTopic.forumTopic, 'icon_color' | 'icon_emoji_id' | 'title' | 'id'>,
   plain?: boolean
 } & WrapSomethingOptions;
-export async function wrapTopicIcon<T extends WrapTopicIconOptions>(options: T): Promise<T['plain'] extends true ? string : HTMLElement | DocumentFragment> {
+
+export async function wrapTopicIcon(options: WrapTopicIconOptions & {plain: true}): Promise<string>;
+export async function wrapTopicIcon(options: WrapTopicIconOptions & {plain?: false}): Promise<HTMLElement | DocumentFragment>;
+export async function wrapTopicIcon(options: WrapTopicIconOptions): Promise<string | HTMLElement | DocumentFragment>;
+
+export async function wrapTopicIcon(options: WrapTopicIconOptions): Promise<string | HTMLElement | DocumentFragment> {
   const topic = options.topic;
 
   let iconEmojiId = topic?.icon_emoji_id;
@@ -85,7 +90,7 @@ export async function wrapTopicIcon<T extends WrapTopicIconOptions>(options: T):
     }).then((fragment) => {
       fragment.lastElementChild.classList.add('topic-icon');
       return fragment;
-    }) as any;
+    });
 }
 
 function wrapMessageActionTopicIcon(options: WrapMessageActionTextOptions) {


### PR DESCRIPTION
When doing `pnpm install`, the newest compatible version of TS gets installed because of the `^` in the `package.json` version. The `5.8.2` version of TS breakes some typings. Basically the same problem as in #414 but with a nicer approach