### PR TITLE
fix: prevent rightSidebar shadow from sticking out

### DIFF
--- a/src/scss/partials/_rightSidebar.scss
+++ b/src/scss/partials/_rightSidebar.scss
@@ -38,7 +38,7 @@
     position: absolute;
     inset-inline-end: 0;
     z-index: 3;
-    transform: translate3d(calc(var(--right-column-width) * var(--reflect)), 0, 0);
+    transform: translate3d(calc((var(--right-column-width) + 0.5rem) * var(--reflect)), 0, 0);
     //transform: translate3d(calc(var(--right-column-width) + 1px), 0, 0);
   
     .sidebar-content {


### PR DESCRIPTION
this PR fixes rightSidebar's position on medium screens when it's moved out of view. this is a very minor issue, but it irritates me every time i use telegram.

the shadow sticks out because current positioning doesn't accommodate for the `0.5rem` shadow:
<img width="943" alt="image" src="https://github.com/user-attachments/assets/f8d28db3-6e52-41c9-921d-00c5d6073930" />

but after the fix it's no longer visible, as it's supposed to be:
<img width="952" alt="image" src="https://github.com/user-attachments/assets/580de500-3841-4e51-9d62-9c87d9347393" />

i feel like best way to prevent this kind of issue in the future would be to move the x size of the border/shadow into a variable, lmk if that's acceptable and i'll force push changes here!