### PR TITLE
Fix transcribe button being on top of replies

### DIFF
--- a/src/scss/partials/_chatBubble.scss
+++ b/src/scss/partials/_chatBubble.scss
@@ -532,8 +532,14 @@
     &--transcribe {
       font-size: 1.375rem;
     }
+
     &--lifted {
       bottom: calc(var(--message-beside-button-size) + 0.25rem);
+    }
+
+    .with-beside-replies &--lifted {
+      bottom: 0;
+      inset-inline-end: calc(var(--message-beside-button-margin) - var(--message-beside-button-size) - 0.25rem);
     }
   }
 


### PR DESCRIPTION
Before:
<img width="1206" height="998" alt="image" src="https://github.com/user-attachments/assets/e228b10e-b01e-4e5c-ae51-9a16b4b04cf8" />


After:
<img width="697" height="377" alt="image" src="https://github.com/user-attachments/assets/7674ecfd-172c-4dc1-a864-6096a37507df" />
