### PR TITLE
Fix all chats dialog being updated with the wrong data

### DIFF
--- a/src/components/forumTab/monoforumTab.ts
+++ b/src/components/forumTab/monoforumTab.ts
@@ -65,12 +65,6 @@ export class MonoforumTab extends ForumTab {
         }
       }
     });
-
-    this.listenerSetter.add(rootScope)('dialog_unread', ({dialog}) => {
-      if(isDialog(dialog)) {
-        this.updateAllChatsDialog(dialog);
-      }
-    });
   }
 
   private updateAllChatsDialog(dialog: Dialog.dialog) {


### PR DESCRIPTION
The unread mark is no longer displayed for the 'all chats' dialog anyway so that piece of code is useless