### PR TITLE
Fix several small bugs

### DIFF
--- a/src/components/chat/bubbleParts/chatThreadSeparator.module.scss
+++ b/src/components/chat/bubbleParts/chatThreadSeparator.module.scss
@@ -73,10 +73,10 @@ $round-border-radius: 100px;
   height: 2px;
 
   opacity: 0.075;
-  background-image: url(assets/img/chat-thread-separator-dash-black.svg);
+  background-image: url('/assets/img/chat-thread-separator-dash-black.svg');
   :global(.night) & {
     opacity: 0.15;
-    background-image: url(assets/img/chat-thread-separator-dash.svg);
+    background-image: url('/assets/img/chat-thread-separator-dash.svg');
   }
 
   &Left {

--- a/src/components/mediaEditor/mediaEditor.scss
+++ b/src/components/mediaEditor/mediaEditor.scss
@@ -1041,7 +1041,7 @@
       position: relative;
       flex: 1;
 
-      mask-image: url(assets/img/media-editor-rotation-wheel-mask.svg);
+      mask-image: url('/assets/img/media-editor-rotation-wheel-mask.svg');
       mask-size: 100% 100%;
     }
 
@@ -1267,7 +1267,7 @@
 
       &--vertical {
         background-size: 1px 9px;
-        background-image: url(assets/img/media-editor-border-part-vertical.svg);
+        background-image: url('/assets/img/media-editor-border-part-vertical.svg');
         top: 0;
         width: 1px;
         height: 100%;
@@ -1280,7 +1280,7 @@
 
       &--horizontal {
         background-size: 9px 1px;
-        background-image: url(assets/img/media-editor-border-part.svg);
+        background-image: url('/assets/img/media-editor-border-part.svg');
         left: 0;
         height: 1px;
         width: 100%;

--- a/src/components/peerProfile.tsx
+++ b/src/components/peerProfile.tsx
@@ -780,12 +780,7 @@ PeerProfile.Birthday = () => {
     const birthday$ = birthday();
     if(!birthday$) return '';
 
-    const date = new Date();
-    date.setDate(birthday$.day);
-    date.setMonth(birthday$.month - 1);
-    if(birthday$.year) {
-      date.setFullYear(birthday$.year);
-    }
+    const date = new Date(birthday$.year ?? new Date().getFullYear(), birthday$.month - 1, birthday$.day);
 
     const el = new I18n.IntlDateElement({
       date,

--- a/src/lib/appManagers/appMessagesManager.ts
+++ b/src/lib/appManagers/appMessagesManager.ts
@@ -8645,6 +8645,7 @@ export class AppMessagesManager extends AppManager {
       message.peerId === this.appPeersManager.peerId ||
       this.appPeersManager.isBroadcast(message.peerId) ||
       this.appPeersManager.isMonoforum(message.peerId) ||
+      this.appPeersManager.isBot(message.peerId) ||
       (message as Message.message).pFlags.is_scheduled
     ) {
       return false;

--- a/src/scss/partials/_avatar.scss
+++ b/src/scss/partials/_avatar.scss
@@ -151,7 +151,7 @@
 
   &.is-monoforum {
     border-bottom-left-radius: 0;
-    mask-image: url(assets/img/monoforum-avatar-mask.svg);
+    mask-image: url('/assets/img/monoforum-avatar-mask.svg');
     mask-size: 100% 100%;
   }
 

--- a/src/scss/partials/_chatBubble.scss
+++ b/src/scss/partials/_chatBubble.scss
@@ -3831,12 +3831,12 @@
     height: 2px;
 
     opacity: 0.075;
-    background-image: url(assets/img/chat-thread-separator-dash-black.svg);
+    background-image: url('/assets/img/chat-thread-separator-dash-black.svg');
   }
 
   .night &::before {
     opacity: 0.15;
-    background-image: url(assets/img/chat-thread-separator-dash.svg);
+    background-image: url('/assets/img/chat-thread-separator-dash.svg');
   }
 }
 


### PR DESCRIPTION
- Hide message read info in context menu for bot chats
- Fix broken asset URLs in SCSS (url(assets/...) resolved relative to the CSS file, e.g. /partials/assets/... instead of /assets/...); this also fixes the monoforum avatar mask, media editor assets and chat thread separator backgrounds
- Fix birthday display for dates where the day does not exist in the current month (e.g. Oct 31 while today is April): the previous setDate/setMonth/setFullYear sequence overflowed the day; use the Date constructor directly