### PR TITLE
fix: persist contact sign-up notification preference across reloads

### DIFF
--- a/src/config/state.ts
+++ b/src/config/state.ts
@@ -170,6 +170,7 @@ export type State = {
   hideChatJoinRequests: {[peerId: PeerId]: number},
   // stateId?: number, // ! DEPRECATED
   notifySettings: {[k in Exclude<NotifyPeer['_'], 'notifyPeer'>]?: PeerNotifySettings.peerNotifySettings},
+  notifyContactsSignUp?: boolean,
   confirmedWebViews: BotId[],
   hiddenSimilarChannels: number[],
   appConfig: MTAppConfig,
@@ -438,6 +439,7 @@ export const STATE_INIT: State = {
   hideChatJoinRequests: {},
   // stateId: nextRandomUint(32),
   notifySettings: {},
+  notifyContactsSignUp: true,
   confirmedWebViews: [],
   hiddenSimilarChannels: [],
   appConfig: {} as any,

--- a/src/lib/appManagers/appNotificationsManager.ts
+++ b/src/lib/appManagers/appNotificationsManager.ts
@@ -55,6 +55,10 @@ export class AppNotificationsManager extends AppManager {
           });
         }
       }
+
+      if(state.notifyContactsSignUp !== undefined) {
+        this.notifyContactsSignUp = Promise.resolve(state.notifyContactsSignUp);
+      }
     });
   }
 
@@ -141,8 +145,9 @@ export class AppNotificationsManager extends AppManager {
 
   public setContactSignUpNotification(silent: boolean) {
     this.apiManager.invokeApi('account.setContactSignUpNotification', {silent})
-    .then((value) => {
+    .then(() => {
       this.notifyContactsSignUp = Promise.resolve(!silent);
+      this.appStateManager.pushToState('notifyContactsSignUp', !silent);
     });
   }
 


### PR DESCRIPTION
Add notifyContactsSignUp to State and STATE_INIT so the preference survives page reloads. Previously, toggling the setting called account.setContactSignUpNotification but never saved the result to IndexedDB, causing the UI to revert to the server value on next load.

On startup, restore the cached value from state so the API is not called unnecessarily.