### PR TITLE
Update getCallProtocol.ts library_versions to try add support P2P calls again in all official telegram clients

### DIFF
--- a/src/lib/calls/p2P/getCallProtocol.ts
+++ b/src/lib/calls/p2P/getCallProtocol.ts
@@ -20,6 +20,6 @@ export default function getCallProtocol(): PhoneCallProtocol {
     },
     min_layer: 92,
     max_layer: 92,
-    library_versions: ['4.0.0']
+    library_versions: ['7.0.0']
   };
 }


### PR DESCRIPTION
Update getCallProtocol.ts library_versions to try add support P2P calls again in all official telegram clients

from 4.0.0 legacy
to modern 7.0.0

https://github.com/morethanwords/tweb/issues/642


maybe issues is here

https://github.com/morethanwords/tweb/blob/master/src/lib/calls/p2P/getCallProtocol.ts

```
import {PhoneCallProtocol} from '@layer';

export default function getCallProtocol(): PhoneCallProtocol {
  return {
    _: 'phoneCallProtocol',
    pFlags: {
      udp_p2p: true,
      udp_reflector: true
    },
    min_layer: 92,
    max_layer: 92,
    library_versions: ['4.0.0']
  };
}
```

maybe need change it to `library_versions `to something updated like `7.0.0`
seems old legacy `4.0.0` it mapeed to `6.0.0` and signaling v1
so we can try do `7.0.0` maybe
```

    library_versions: ['7.0.0']
  };
}
```