### PR TITLE
fix: #223 draft sync loop when remote client clears draft

### DIFF
--- a/src/components/chat/input.ts
+++ b/src/components/chat/input.ts
@@ -51,7 +51,7 @@ import MentionsHelper from '@components/chat/mentionsHelper';
 import fixSafariStickyInput from '@helpers/dom/fixSafariStickyInput';
 import ReplyKeyboard from '@components/chat/replyKeyboard';
 import InlineHelper from '@components/chat/inlineHelper';
-import debounce from '@helpers/schedulers/debounce';
+import debounce, {DebounceReturnType} from '@helpers/schedulers/debounce';
 import {putPreloader} from '@components/putPreloader';
 import SetTransition from '@components/singleTransition';
 import PeerTitle from '@components/peerTitle';
@@ -332,7 +332,7 @@ export default class ChatInput {
 
   private btnPreloader: HTMLButtonElement;
 
-  private saveDraftDebounced: () => void;
+  private saveDraftDebounced: DebounceReturnType<() => void>;
 
   private fakeRowsWrapper: HTMLDivElement;
 
@@ -1536,6 +1536,9 @@ export default class ChatInput {
       }
 
       if(this.chat.threadId !== threadId || this.chat.monoforumThreadId !== monoforumThreadId || this.chat.peerId !== peerId || PEER_EXCEPTIONS.has(this.chat.type)) return;
+      if(!draft) {
+        this.saveDraftDebounced.clearTimeout();
+      }
       this.setDraft(draft, true, force);
     });
 
@@ -2389,7 +2392,7 @@ export default class ChatInput {
 
   public async setDraft(draft?: MyDraftMessage, fromUpdate = true, force = false) {
     if(
-      (!force && !isInputEmpty(this.messageInput)) ||
+      (!force && draft && !isInputEmpty(this.messageInput)) ||
       PEER_EXCEPTIONS.has(this.chat.type)
     ) {
       return false;
@@ -2419,9 +2422,12 @@ export default class ChatInput {
               this.onMessageSent();
             });
           });
+        } else if(fromUpdate && !this.saveDraftDebounced.isDebounced()) {
+          this.clearInput();
+          this.clearHelper();
         }
 
-        return false;
+        return fromUpdate;
       }
     }
 

--- a/src/components/chat/input.ts
+++ b/src/components/chat/input.ts
@@ -1537,6 +1537,9 @@ export default class ChatInput {
 
       if(this.chat.threadId !== threadId || this.chat.monoforumThreadId !== monoforumThreadId || this.chat.peerId !== peerId || PEER_EXCEPTIONS.has(this.chat.type)) return;
       if(!draft) {
+        // a pending local save means the user is actively typing newer content —
+        // let it win and sync normally instead of clobbering it with the remote clear
+        if(this.saveDraftDebounced.isDebounced()) return;
         this.saveDraftDebounced.clearTimeout();
       }
       this.setDraft(draft, true, force);


### PR DESCRIPTION
fixes #223 

I found there's a guard in `setDraft` that's supposed to protect a user's local input from being overwritten by remote updates. This was silently ignoring remote draft clears, causing the client to re-push the cleared draft once the debounce on `saveDraft` elapses.

I've changed the guard to only bail out when a draft is provided. It will also only clear if there isn't already a pending local draft save (implying the user is actively typing).

This bug has been annoying me for a while, so will be happy to finally get it fixed!