### PR TITLE
Fix rich-message media collapsing in chat bubbles

### DIFF
--- a/src/components/instantView.module.scss
+++ b/src/components/instantView.module.scss
@@ -56,6 +56,15 @@
   min-height: 0;
   font-size: inherit;
   line-height: inherit;
+  // Inline rich messages live in chat bubbles, outside the in-app browser that
+  // normally defines --browser-width. Use the media wrapper's measured width
+  // and aspect ratio so photo/video blocks retain a real layout box.
+  .Media {
+    --width: var(--iv-media-width);
+    max-width: 100%;
+    height: auto !important;
+    aspect-ratio: var(--aspect-ratio);
+  }
 }
 
 .RichMessageWrapper {

--- a/src/components/instantView.tsx
+++ b/src/components/instantView.tsx
@@ -313,6 +313,10 @@ function _onMediaResult(
   height: number,
   paddings: number
 ) {
+  if(Number.isFinite(width) && width > 0) {
+    ref.style.setProperty('--iv-media-width', width + 'px');
+  }
+
   ref.style.setProperty(
     '--aspect-ratio',
     '' + (width / height)


### PR DESCRIPTION
## Summary

- preserve the measured width of Instant View photo/video wrappers as a CSS custom property
- use that width and the existing aspect ratio when the same media renderer is embedded in an inline rich-message chat bubble
- keep full-page Instant View sizing unchanged

## Root cause

`RichMessageBubble` reuses the Instant View block renderer outside the in-app browser. The shared `.Media` rule calculates both dimensions from `--browser-width`, but that variable is only defined by the browser container. In chat bubbles the declaration becomes invalid; the absolutely positioned image still downloads and decodes, while its media wrapper collapses to `0px` height.

The inline override uses the width already calculated by the photo/video wrapper and lets `aspect-ratio` derive the responsive height. This avoids changing the MTProto rich-message payload or duplicating media as ordinary message media.

## Verification

- reproduced with an Android full-screen rich message containing a 570×1280 JPEG: before the patch the decoded image had `naturalHeight=1280` but `clientHeight=0`
- after the patch the same message renders at 178×400
- `pnpm exec vitest run src/tests/richMessage.test.ts` (9 tests passed)
- `pnpm run lint`
- `pnpm run build` (includes `tsc --noEmit`)

Note: local validation used Node 22.15.1, while the current repository declares Node ^22.18.0; all checks above completed successfully.