### PR TITLE
fix: crisp full media for large stickers/custom emoji

### DIFF
--- a/src/components/wrappers/sticker.ts
+++ b/src/components/wrappers/sticker.ts
@@ -62,6 +62,9 @@ const getThumbFromContainer = (container: HTMLElement) => {
   return element;
 };
 
+/** Below this CSS size, low-res photoSize thumbs are OK for list performance; at/above prefer full Lottie/WebM. */
+const FULL_MEDIA_SIZE_THRESHOLD = 64;
+
 export default async function wrapSticker({doc, div, middleware, loadStickerMiddleware, lazyLoadQueue, exportLoad, group, play, onlyThumb, emoji, width, height, withThumb, loop, loadPromises, needFadeIn, needUpscale, skipRatio, static: asStatic, managers = rootScope.managers, fullThumb, isOut, noPremium, withLock, relativeEffect, loopEffect, isCustomEmoji, syncedVideo, liteModeKey, isEffect, textColor, scrollable, showPremiumInfo, useCache, initFrame, keepThumb, noOffscreen, compositorDelivery}: {
   doc: MyDocument,
   div: HTMLElement | HTMLElement[],
@@ -125,6 +128,18 @@ export default async function wrapSticker({doc, div, middleware, loadStickerMidd
     const size = makeMediaSize(doc.w, doc.h).aspectFitted(boxSize);
     width = size.width;
     height = size.height;
+  }
+
+  // Large stickers/emoji must not stay on photoSize thumbs (blurry upscale), even if
+  // the caller passed `static: true`. Tiny list slots (< threshold) still use thumbs.
+  const forcedStatic = stickerType === StickerType.Static ||
+    (stickerType === StickerType.WebM && !IS_WEBM_SUPPORTED);
+  if(
+    asStatic &&
+    !forcedStatic &&
+    Math.max(width || 0, height || 0) >= FULL_MEDIA_SIZE_THRESHOLD
+  ) {
+    asStatic = false;
   }
 
   if(stickerType === StickerType.Lottie) {


### PR DESCRIPTION
## Summary
- Prefer full Lottie/WebM document media for large sticker/custom-emoji displays (`CSS size >= 64`) instead of upscaling low-res `photoSize` thumbs when callers pass `static: true`.
- Keep thumbnail/static path for tiny list slots and for true static stickers / unsupported WebM.
- Mirrors the approach in Ajaxy/telegram-tt#539 for the same class of blurry fullscreen/pack-preview emoji.

Fixes #701  
Tracking: https://github.com/HyperlinksSpace/HyperlinksSpaceProgram/issues/92

## Test plan
- [ ] Open an animated/custom emoji or sticker fullscreen / sticker viewer hold-preview — animation (or first crisp frame) should look sharp, not pixelated.
- [ ] Open a sticker/emoji pack popup with large cells — animated stickers should load full media, not soft thumbs.
- [ ] Confirm tiny inline custom emoji in message text / emoji picker lists still use lightweight thumbs (no unexpected heavy downloads for every cell).
- [ ] Static (webp) stickers and WebM-on-unsupported-browsers still render via the static path.


Made with [Cursor](https://cursor.com)